### PR TITLE
Allow multiple exclude patterns.

### DIFF
--- a/NChurn.Core/Analyzers/Analyzer.cs
+++ b/NChurn.Core/Analyzers/Analyzer.cs
@@ -80,9 +80,13 @@ namespace NChurn.Core.Analyzers
         {
             _includes.Add(new Regex(pattern, RegexOptions.Compiled));
         }
-        public void AddExclude(string pattern)
+
+        public void AddExcludes(params string[] patterns)
         {
-            _excludes.Add(new Regex(pattern, RegexOptions.Compiled));
+            foreach (var pattern in patterns)
+            {
+                _excludes.Add(new Regex(pattern, RegexOptions.Compiled));
+            }
         }
     }
 }

--- a/NChurn/Program.cs
+++ b/NChurn/Program.cs
@@ -50,8 +50,8 @@ namespace NChurn
             [Option("i", "input", Required = false, HelpText = "Get input from a file instead of running a versioning system. Must specify correct adapter via -a.")]
             public string InputFile = null;
 
-            [Option("x", "exclude", Required = false, HelpText = "Exclude resources matching this regular expression")]
-            public string ExcludePattern = null;
+            [OptionArray("x", "exclude", Required = false, HelpText = "Exclude resources matching this regular expression")]
+            public string[] ExcludePatterns = null;
 
             [Option("n", "include", Required = false, HelpText = "Include resources matching this regular expression")]
             public string IncludePattern = null;
@@ -146,8 +146,8 @@ namespace NChurn
                 
                 if (!string.IsNullOrEmpty(options.IncludePattern))
                     analyzer.AddInclude(options.IncludePattern);
-                if(!string.IsNullOrEmpty(options.ExcludePattern))
-                    analyzer.AddExclude(options.ExcludePattern);
+                if(options.ExcludePatterns.Length > 0)
+                    analyzer.AddExcludes(options.ExcludePatterns);
                 
                 if(options.InputFile != null && !File.Exists(options.InputFile))
                 {


### PR DESCRIPTION
If you want to exclude multiple file types, it's a lot easier to supply multiple patterns rather than trying to create one super-regex:

e.g. nchurn -x csproj$ packages.config
